### PR TITLE
Change branch length label to 'snps'

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -494,7 +494,7 @@
                             "description": "Node labels",
                             "$comment": "Auspice scans this to generate the branch labels dropdown",
                             "patternProperties": {
-                                "^[a-zA-Z0-9]+$": {
+                                "^[0-9]+$": {
                                     "$comment": "e.g. clade->3c3a",
                                     "$comment": "string is parsed unchanged by Auspice",
                                     "type": "string"

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -495,8 +495,8 @@
                             "$comment": "Auspice scans this to generate the branch labels dropdown",
                             "patternProperties": {
                                 "^[0-9]+$": {
-                                    "$comment": "e.g. clade->3c3a",
-                                    "$comment": "string is parsed unchanged by Auspice",
+                                    "$comment": "simple integer for number of snps",
+                                    "$comment": "number is parsed as string, unchanged by Auspice",
                                     "type": "string"
                                 }
                             }

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -728,9 +728,9 @@ def set_node_attrs_on_tree(data_json, node_attrs):
     def _transfer_branch_lengths(node, raw_data):
         if "branch_length" in raw_data and is_valid(raw_data["branch_length"]):
             if 'labels' in node["branch_attrs"]:
-                node["branch_attrs"]["labels"]['#snps'] = raw_data["branch_length"]
+                node["branch_attrs"]["labels"]['snps'] = raw_data["branch_length"]
             else:
-                node["branch_attrs"]["labels"] = { "#snps": raw_data["branch_length"] }
+                node["branch_attrs"]["labels"] = { "snps": raw_data["branch_length"] }
 
     def _transfer_hidden_flag(node, raw_data):
         hidden = raw_data.get("hidden", None)


### PR DESCRIPTION
Change the branch length label from '#snps' to just 'snps'.  This makes it cleaner for the display and more straightforward in the URL.