### PR TITLE
Refine Color-by options

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -385,8 +385,8 @@ def set_colorings(data_json, config, command_line_colorings, metadata_names, nod
         # note that invalid options will be pruned out later
         # it is here that we deal with the interplay between node-data "traits", command line colorings &
         # config provided options
-        auto_colorings = [name for name in node_data_colorings
-                          if node_data_prop_is_normal_trait(name) and name not in metadata_names]
+        # auto_colorings = [name for name in node_data_colorings
+        #                  if node_data_prop_is_normal_trait(name) and name not in metadata_names]
 
         colorings = []
         # If we have command line colorings, it seems we (a) ignore any provided in the config file
@@ -394,8 +394,8 @@ def set_colorings(data_json, config, command_line_colorings, metadata_names, nod
         # type will be accessed from the config file if available)
         if command_line_colorings:
             # start with auto_colorings (already validated to be included)
-            for x in auto_colorings:
-                colorings.append(_create_coloring(x))
+            #for x in auto_colorings:
+            #    colorings.append(_create_coloring(x))
             # then add in command line colorings
             for x in command_line_colorings:
                 colorings.append(_create_coloring(x))
@@ -405,17 +405,17 @@ def set_colorings(data_json, config, command_line_colorings, metadata_names, nod
                 for x in config.keys():
                     colorings.append(_create_coloring(x))
             # then add in any auto-colorings already validated to include
-            for x in auto_colorings:
-                colorings.append(_create_coloring(x))
+            #for x in auto_colorings:
+            #    colorings.append(_create_coloring(x))
 
-        explicitly_defined_colorings = [x["key"] for x in colorings]
+        #explicitly_defined_colorings = [x["key"] for x in colorings]
         # add in genotype as a special case if (a) not already set and (b) the data supports it
-        if "gt" not in explicitly_defined_colorings and are_mutations_defined(node_attrs):
-            colorings.insert(0,{'key':'gt'})
-        if "num_date" not in explicitly_defined_colorings and are_dates_defined(node_attrs):
-            colorings.insert(0,{'key':'num_date'})
-        if "clade_membership" not in explicitly_defined_colorings and are_clades_defined(node_attrs):
-            colorings.insert(0,{'key':'clade_membership'})
+        #if "gt" not in explicitly_defined_colorings and are_mutations_defined(node_attrs):
+        #    colorings.insert(0,{'key':'gt'})
+        #if "num_date" not in explicitly_defined_colorings and are_dates_defined(node_attrs):
+        #    colorings.insert(0,{'key':'num_date'})
+        #if "clade_membership" not in explicitly_defined_colorings and are_clades_defined(node_attrs):
+        #    colorings.insert(0,{'key':'clade_membership'})
 
         return colorings
 


### PR DESCRIPTION
This PR removes the automated insertion of 'Genotype' and 'confidence' as options in the color-by drop-down selection in Nextstrain.  Again the functionality is just commented out.

During testing it was identified that these options were not needed (and indeed, not functional).  After failing to find an option to change this in Auspice, their input was tracked down to Augur, where they are added to the exported json file.   