### PR TITLE
Change snp to SNP Distance

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -728,9 +728,9 @@ def set_node_attrs_on_tree(data_json, node_attrs):
     def _transfer_branch_lengths(node, raw_data):
         if "branch_length" in raw_data and is_valid(raw_data["branch_length"]):
             if 'labels' in node["branch_attrs"]:
-                node["branch_attrs"]["labels"]['snps'] = raw_data["branch_length"]
+                node["branch_attrs"]["labels"]['SNP Distance'] = raw_data["branch_length"]
             else:
-                node["branch_attrs"]["labels"] = { "snps": raw_data["branch_length"] }
+                node["branch_attrs"]["labels"] = { "SNP Distance": raw_data["branch_length"] }
 
     def _transfer_hidden_flag(node, raw_data):
         hidden = raw_data.get("hidden", None)


### PR DESCRIPTION
Just a small update to change the branch labels from 'snps' to 'SNP distance'.  

This has the effect of fixing what's in the json files which are generated by [btb-forestry](https://github.com/APHA-CSU/btb-forestry) and viewed in [Auspice](https://github.com/APHA-CSU/auspice)