### PR TITLE
allow space in branch label pattern

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -179,7 +179,7 @@
                     "description": "What branch label should be displayed by default, or 'none' to hide labels by default.",
                     "$comment": "Should be a key present in the per-node branch_attrs.labels object of the exported JSON; pattern is from the schema for that object",
                     "type": "string",
-                    "pattern": "^(none|[a-zA-Z0-9]+)$"
+                    "pattern": "^(none|[a-zA-Z0-9 ]+)$"
                 },
                 "transmission_lines": {
                     "type": "boolean"

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -261,7 +261,7 @@
                             "description": "What branch label should be displayed by default, or 'none' to hide labels by default.",
                             "$comment": "Should be a key present in the per-node branch_attrs.labels object of the exported JSON; pattern is from the schema for that object",
                             "type": "string",
-                            "pattern": "^(none|[a-zA-Z0-9]+)$"
+                            "pattern": "^(none|[a-zA-Z0-9 ]+)$"
                         },
                         "transmission_lines": {
                             "description": "Should transmission lines (if available) be displaye by default",


### PR DESCRIPTION
Just a small change to allow the pattern to include a space for 'SNP Distance' 