### PR TITLE
Round branch lengths

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -38,7 +38,7 @@ from collections import defaultdict
 from .argparse_ import add_validation_arguments
 from .util_support.node_data_file import NodeDataObject
 
-def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
+def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=False,
                                  marginal=False, fill_overhangs=True, infer_tips=False,
                                  alphabet='nuc', rng_seed=None):
     """infer ancestral sequences using TreeTime

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -846,9 +846,9 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
     def _transfer_branch_lengths(node, raw_data):
         if "branch_length" in raw_data and is_valid(raw_data["branch_length"]):
             if 'labels' in node["branch_attrs"]:
-                node["branch_attrs"]["labels"]['SNP Distance'] = raw_data["branch_length"]
+                node["branch_attrs"]["labels"]['SNP Distance'] = round(raw_data["branch_length"])
             else:
-                node["branch_attrs"]["labels"] = { "SNP Distance": raw_data["branch_length"] }
+                node["branch_attrs"]["labels"] = { "SNP Distance": round(raw_data["branch_length"]) }
 
     def _transfer_hidden_flag(node, raw_data):
         hidden = raw_data.get("hidden", None)
@@ -899,7 +899,7 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
         _transfer_additional_metadata_columns(node, raw_data)
         # transfer "special cases"
         _transfer_vaccine_info(node, raw_data)
-        _transfer_labels(node, raw_data)
+        #_transfer_labels(node, raw_data)
         _transfer_branch_lengths(node, raw_data) # add branch length as label
         _transfer_hidden_flag(node, raw_data)
         _transfer_num_date(node, raw_data)


### PR DESCRIPTION
This PR just adds an additional function to round any float branch length labels to the nearest integer.  This is only needed for a few cases and just makes sure the display of tress in Nextstrain remains uncluttered.